### PR TITLE
Allow an empty cite reference in the TRE json

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/FileProcessor.scala
+++ b/src/main/scala/uk/gov/nationalarchives/FileProcessor.scala
@@ -207,7 +207,7 @@ class FileProcessor(
       fileMetadataChecksum: String,
       bagitTxtChecksum: String,
       manifestSha256Checksum: String,
-      bagInfoChecksum: Option[String]
+      potentialBagInfoChecksum: Option[String]
   ): IO[String] = {
     val tagManifestMap = Map(
       "folder-metadata.csv" -> folderMetadataChecksum,
@@ -216,7 +216,7 @@ class FileProcessor(
       "bagit.txt" -> bagitTxtChecksum,
       "manifest-sha256.txt" -> manifestSha256Checksum
     )
-    val tagManifest = bagInfoChecksum
+    val tagManifest = potentialBagInfoChecksum
       .map(cs => tagManifestMap + ("bag-info.txt" -> cs))
       .getOrElse(tagManifestMap)
       .toSeq

--- a/src/main/scala/uk/gov/nationalarchives/FileProcessor.scala
+++ b/src/main/scala/uk/gov/nationalarchives/FileProcessor.scala
@@ -3,6 +3,7 @@ package uk.gov.nationalarchives
 import cats.data.NonEmptyList
 import cats.effect.IO
 import cats.effect.kernel.Resource
+import cats.implicits._
 import fs2.compression.Compression
 import fs2.data.csv.{Row, lowlevel}
 import fs2.interop.reactivestreams._
@@ -10,6 +11,7 @@ import fs2.io._
 import fs2.{Chunk, Pipe, Stream, text}
 import org.apache.commons.codec.binary.Hex
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream
+import ujson.{Null, Value}
 import uk.gov.nationalarchives.FileProcessor._
 import upickle.default._
 
@@ -58,8 +60,8 @@ class FileProcessor(
       fileInfo: FileInfo,
       metadataFileInfo: FileInfo,
       cite: String,
-      department: String,
-      series: String
+      department: Option[String],
+      series: Option[String]
   ): IO[String] = {
     val title = fileInfo.fileName.split("\\.").dropRight(1).mkString(".")
     val folderMetadataHeader = NonEmptyList("identifier", List("parentPath", "name", "title"))
@@ -106,8 +108,7 @@ class FileProcessor(
         "manifest-sha256.txt",
         manifestString.getBytes.length
       )
-      bagInfoString = s"Department: $department\nSeries: $series"
-      bagInfoChecksum <- uploadAsFile(bagInfoString, "bag-info.txt", bagInfoString.getBytes.length)
+      bagInfoChecksum <- createBagInfo(department, series)
       tagManifest <- createTagManifest(
         folderMetadataChecksum,
         assetMetadataChecksum,
@@ -118,6 +119,16 @@ class FileProcessor(
       )
     } yield tagManifest
   }
+
+  private def createBagInfo(departmentOpt: Option[String], seriesOpt: Option[String]): IO[Option[String]] = {
+    for {
+      department <- departmentOpt
+      series <- seriesOpt
+    } yield {
+      val bagInfoString = s"Department: $department\nSeries: $series"
+      uploadAsFile(bagInfoString, "bag-info.txt", bagInfoString.getBytes.length)
+    }
+  }.sequence
 
   private def extractMetadataFromJson(str: Stream[IO, Byte]): Stream[IO, TREMetadata] = {
     str
@@ -196,16 +207,19 @@ class FileProcessor(
       fileMetadataChecksum: String,
       bagitTxtChecksum: String,
       manifestSha256Checksum: String,
-      bagInfoChecksum: String
+      bagInfoChecksum: Option[String]
   ): IO[String] = {
-    val tagManifest = Map(
+    val tagManifestMap = Map(
       "folder-metadata.csv" -> folderMetadataChecksum,
       "asset-metadata.csv" -> assetMetadataChecksum,
       "file-metadata.csv" -> fileMetadataChecksum,
       "bagit.txt" -> bagitTxtChecksum,
-      "manifest-sha256.txt" -> manifestSha256Checksum,
-      "bag-info.txt" -> bagInfoChecksum
-    ).toSeq
+      "manifest-sha256.txt" -> manifestSha256Checksum
+    )
+    val tagManifest = bagInfoChecksum
+      .map(cs => tagManifestMap + ("bag-info.txt" -> cs))
+      .getOrElse(tagManifestMap)
+      .toSeq
       .sortBy(_._1)
       .map { case (file, checksum) =>
         s"$checksum $file"
@@ -231,6 +245,11 @@ object FileProcessor {
     dateString => LocalDate.parse(dateString)
   )
 
+  implicit def OptionReader[T: Reader]: Reader[Option[T]] = reader[Value].map[Option[T]] {
+    case Null    => None
+    case jsValue => Some(read[T](jsValue))
+  }
+
   case class FileInfo(id: UUID, fileSize: Long, fileName: String, checksum: String)
 
   case class TREInputParameters(status: String, reference: String, s3Bucket: String, s3Key: String)
@@ -242,7 +261,7 @@ object FileProcessor {
   case class Parser(
       uri: String,
       court: String,
-      cite: String,
+      cite: Option[String] = None,
       date: LocalDate,
       name: String,
       attachments: List[String] = Nil,

--- a/src/main/scala/uk/gov/nationalarchives/Lambda.scala
+++ b/src/main/scala/uk/gov/nationalarchives/Lambda.scala
@@ -46,7 +46,7 @@ class Lambda extends RequestHandler[SQSEvent, Unit] {
         _ <- fileProcessor.createMetadataFiles(
           fileInfo.copy(checksum = payload.sha256),
           metadataFileInfo,
-          cite,
+          cite.getOrElse("Court Documents"),
           output.department,
           output.series
         )

--- a/src/main/scala/uk/gov/nationalarchives/SeriesMapper.scala
+++ b/src/main/scala/uk/gov/nationalarchives/SeriesMapper.scala
@@ -5,8 +5,8 @@ import uk.gov.nationalarchives.SeriesMapper._
 import upickle.default._
 
 class SeriesMapper(courts: Set[Court]) {
-  def createOutput(uploadBucket: String, batchId: String, citeOrEmpty: Option[String]): IO[Output] = {
-    citeOrEmpty
+  def createOutput(uploadBucket: String, batchId: String, potentialCite: Option[String]): IO[Output] = {
+    potentialCite
       .map { cite =>
         val filteredSeries = courts.filter(court => cite.contains(court.code))
         filteredSeries.size match {

--- a/src/main/scala/uk/gov/nationalarchives/SeriesMapper.scala
+++ b/src/main/scala/uk/gov/nationalarchives/SeriesMapper.scala
@@ -5,26 +5,37 @@ import uk.gov.nationalarchives.SeriesMapper._
 import upickle.default._
 
 class SeriesMapper(courts: Set[Court]) {
-  def createOutput(uploadBucket: String, batchId: String, cite: String): IO[Output] = {
-    val filteredSeries = courts.filter(court => cite.contains(court.code))
-    filteredSeries.size match {
-      case 1 =>
-        IO {
-          val court = filteredSeries.head
-          Output(batchId, uploadBucket, s"$batchId/", court.dept, court.series)
+  def createOutput(uploadBucket: String, batchId: String, citeOrEmpty: Option[String]): IO[Output] = {
+    citeOrEmpty
+      .map { cite =>
+        val filteredSeries = courts.filter(court => cite.contains(court.code))
+        filteredSeries.size match {
+          case 1 =>
+            IO {
+              val court = filteredSeries.head
+              Output(batchId, uploadBucket, s"$batchId/", Option(court.dept), Option(court.series))
+            }
+          case size: Int =>
+            IO.raiseError(
+              new RuntimeException(s"$size entries found when looking up series for cite $cite and batchId $batchId")
+            )
         }
-      case size: Int =>
-        IO.raiseError(
-          new RuntimeException(s"$size entries found when looking up series for cite $cite and batchId $batchId")
-        )
-    }
+      }
+      .getOrElse(IO(Output(batchId, uploadBucket, s"$batchId/", None, None)))
+
   }
 }
 
 object SeriesMapper {
   implicit val outputWriter: Writer[Output] = macroW[Output]
 
-  case class Output(batchId: String, s3Bucket: String, s3Prefix: String, department: String, series: String)
+  case class Output(
+      batchId: String,
+      s3Bucket: String,
+      s3Prefix: String,
+      department: Option[String],
+      series: Option[String]
+  )
 
   case class Court(code: String, dept: String, series: String)
 

--- a/src/test/scala/uk/gov/nationalarchives/FileProcessorTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/FileProcessorTest.scala
@@ -183,7 +183,7 @@ class FileProcessorTest extends AnyFlatSpec with MockitoSugar with TableDrivenPr
     ex.getMessage should equal("Error downloading metadata file")
   }
 
-  val departmentSeriesTable: TableFor3[Option[String], Option[String], Boolean] = Table(
+  val departmentAndSeriesTable: TableFor3[Option[String], Option[String], Boolean] = Table(
     ("department", "series", "includeBagInfo"),
     (Option("Department"), Option("Series"), true),
     (Option("Department"), None, false),
@@ -191,7 +191,7 @@ class FileProcessorTest extends AnyFlatSpec with MockitoSugar with TableDrivenPr
     (None, None, false)
   )
 
-  forAll(departmentSeriesTable) { (department, series, includeBagInfo) =>
+  forAll(departmentAndSeriesTable) { (department, series, includeBagInfo) =>
     "createMetadataFiles" should s"upload the correct bagit files for $department and $series" in {
       val fileId = UUID.randomUUID()
       val metadataId = UUID.randomUUID()

--- a/src/test/scala/uk/gov/nationalarchives/LambdaTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/LambdaTest.scala
@@ -91,7 +91,6 @@ class LambdaTest extends AnyFlatSpec with BeforeAndAfterEach {
     override val s3: DAS3Client[IO] = DAS3Client[IO](s3AsyncClient)
     override val sfn: DASFNClient[IO] = new DASFNClient(sfnAsyncClient)
     override val seriesMapper: SeriesMapper = new SeriesMapper(Set(Court("cite", "TEST", "TEST SERIES")))
-    var count: Int = -1
     val uuidsIterator: Iterator[String] = uuidsAndChecksum.map(_._1).iterator
 
     override val randomUuidGenerator: () => UUID = () => UUID.fromString(uuidsIterator.next())
@@ -135,10 +134,10 @@ class LambdaTest extends AnyFlatSpec with BeforeAndAfterEach {
       s"""{"parameters":{"TRE":{"reference":"$reference","payload":{"filename":"Test.docx","sha256":"abcde"}},"PARSER":{"cite":"cite","uri":"https://example.com","court":"test","date":"2023-07-26","name":"test"}}}"""
     )
 
-    metadataFilesAndChecksums.foreach { file =>
+    metadataFilesAndChecksums.foreach { case (file, checksum) =>
       s3Server.stubFor(
-        put(urlEqualTo(s"/$testOutputBucket/$reference/${file._1}"))
-          .willReturn(ok().withHeader("x-amz-checksum-sha256", convertChecksumToS3Format(file._2)))
+        put(urlEqualTo(s"/$testOutputBucket/$reference/$file"))
+          .willReturn(ok().withHeader("x-amz-checksum-sha256", convertChecksumToS3Format(checksum)))
       )
     }
 

--- a/src/test/scala/uk/gov/nationalarchives/LambdaTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/LambdaTest.scala
@@ -18,7 +18,7 @@ import uk.gov.nationalarchives.SeriesMapper.{Court, Output}
 import upickle.default._
 
 import java.net.URI
-import java.util.UUID
+import java.util.{Base64, HexFormat, UUID}
 import scala.jdk.CollectionConverters._
 
 class LambdaTest extends AnyFlatSpec with BeforeAndAfterEach {
@@ -35,22 +35,22 @@ class LambdaTest extends AnyFlatSpec with BeforeAndAfterEach {
   case class SFNRequest(stateMachineArn: String, name: String, input: String)
 
   val reference = "TEST-REFERENCE"
-  val uuids: List[String] = List(
-    "c7e6b27f-5778-4da8-9b83-1b64bbccbd03",
-    "61ac0166-ccdf-48c4-800f-29e5fba2efda",
-    "4e6bac50-d80a-4c68-bd92-772ac9701f14",
-    "c2e7866e-5e94-4b4e-a49f-043ad937c18a",
-    "27a9a6bb-a023-4cab-8592-39b44761a30a"
+  val uuids: List[(String, String)] = List(
+    ("c7e6b27f-5778-4da8-9b83-1b64bbccbd03", "71"),
+    ("61ac0166-ccdf-48c4-800f-29e5fba2efda", "81"),
+    ("4e6bac50-d80a-4c68-bd92-772ac9701f14", "91"),
+    ("c2e7866e-5e94-4b4e-a49f-043ad937c18a", "A1"),
+    ("27a9a6bb-a023-4cab-8592-39b44761a30a", "B1")
   )
 
-  val metadataFiles: List[String] = List(
-    "asset-metadata.csv",
-    "bagit.txt",
-    "bag-info.txt",
-    "file-metadata.csv",
-    "folder-metadata.csv",
-    "manifest-sha256.txt",
-    "tagmanifest-sha256.txt"
+  val metadataFiles: List[(String, String)] = List(
+    ("asset-metadata.csv", "01"),
+    ("bagit.txt", "11"),
+    ("bag-info.txt", "21"),
+    ("file-metadata.csv", "31"),
+    ("folder-metadata.csv", "41"),
+    ("manifest-sha256.txt", "51"),
+    ("tagmanifest-sha256.txt", "61")
   )
 
   override def beforeEach(): Unit = {
@@ -66,6 +66,14 @@ class LambdaTest extends AnyFlatSpec with BeforeAndAfterEach {
   val inputBucket = "inputBucket"
   val packageAvailable: TREInput = TREInput(TREInputParameters("status", "TEST-REFERENCE", inputBucket, "test.tar.gz"))
   val event: SQSEvent = createEvent(write(packageAvailable))
+
+  private def runLambdaAndReturnStepFunctionRequest(metadataJsonOpt: Option[String] = None) = {
+    stubAWSRequests(inputBucket, metadataJsonOpt = metadataJsonOpt)
+    IngestParserTest().handleRequest(event, null)
+
+    val sfnEvent = sfnServer.getAllServeEvents.asScala.head
+    read[SFNRequest](sfnEvent.getRequest.getBodyAsString)
+  }
 
   case class IngestParserTest() extends Lambda {
     private val s3AsyncClient: S3AsyncClient = S3AsyncClient
@@ -84,7 +92,7 @@ class LambdaTest extends AnyFlatSpec with BeforeAndAfterEach {
     override val sfn: DASFNClient[IO] = new DASFNClient(sfnAsyncClient)
     override val seriesMapper: SeriesMapper = new SeriesMapper(Set(Court("cite", "TEST", "TEST SERIES")))
     var count: Int = -1
-    val uuidsIterator: Iterator[String] = uuids.iterator
+    val uuidsIterator: Iterator[String] = uuids.map(_._1).iterator
 
     override val randomUuidGenerator: () => UUID = () => UUID.fromString(uuidsIterator.next())
   }
@@ -96,6 +104,12 @@ class LambdaTest extends AnyFlatSpec with BeforeAndAfterEach {
     sqsEvent.setRecords(List(record).asJava)
     sqsEvent
   }
+
+  def convertChecksumToS3Format(cs: String): String =
+    Base64.getEncoder
+      .encode(HexFormat.of().parseHex(cs))
+      .map(_.toChar)
+      .mkString
 
   def stubAWSRequests(
       inputBucket: String,
@@ -123,15 +137,16 @@ class LambdaTest extends AnyFlatSpec with BeforeAndAfterEach {
 
     metadataFiles.foreach { file =>
       s3Server.stubFor(
-        put(urlEqualTo(s"/$testOutputBucket/$reference/$file"))
-          .willReturn(ok())
+        put(urlEqualTo(s"/$testOutputBucket/$reference/${file._1}"))
+          .willReturn(ok().withHeader("x-amz-checksum-sha256", convertChecksumToS3Format(file._2)))
       )
     }
 
-    uuids.foreach { uuid =>
+    uuids.foreach { uuidAndChecksum =>
+      val uuid = uuidAndChecksum._1
       s3Server.stubFor(
         put(urlEqualTo(s"/$testOutputBucket/$uuid"))
-          .willReturn(ok())
+          .willReturn(ok().withHeader("x-amz-checksum-sha256", convertChecksumToS3Format(uuidAndChecksum._2)))
       )
       s3Server.stubFor(
         put(urlEqualTo(s"/$testOutputBucket/$reference/data/$uuid"))
@@ -165,24 +180,60 @@ class LambdaTest extends AnyFlatSpec with BeforeAndAfterEach {
     stubAWSRequests(inputBucket)
     IngestParserTest().handleRequest(event, null)
     val serveEvents = s3Server.getAllServeEvents.asScala
+
     def countPutEvents(name: String) = serveEvents.count(e =>
       e.getRequest.getUrl == s"/$testOutputBucket/$reference/$name" && e.getRequest.getMethod == RequestMethod.PUT
     )
-    metadataFiles.foreach(file => countPutEvents(file) should equal(1))
-    countPutEvents(s"data/${uuids.head}") should equal(1)
-    countPutEvents(s"data/${uuids(1)}") should equal(1)
+
+    metadataFiles.map(_._1).foreach(file => countPutEvents(file) should equal(1))
+    countPutEvents(s"data/${uuids.head._1}") should equal(1)
+    countPutEvents(s"data/${uuids(1)._1}") should equal(1)
+  }
+
+  "the lambda" should "write the correct metadata files to S3" in {
+    stubAWSRequests(inputBucket)
+    IngestParserTest().handleRequest(event, null)
+    val serveEvents = s3Server.getAllServeEvents.asScala
+
+    def filterEvents(name: String) = serveEvents
+      .map(_.getRequest)
+      .find(ev => ev.getUrl == s"/$testOutputBucket/$reference/$name" && ev.getMethod == RequestMethod.PUT)
+      .map(_.getBodyAsString.split("\r\n")(1).trim)
+      .head
+
+    val folderId = "4e6bac50-d80a-4c68-bd92-772ac9701f14"
+    val assetId = "c2e7866e-5e94-4b4e-a49f-043ad937c18a"
+    val fileId = "c7e6b27f-5778-4da8-9b83-1b64bbccbd03"
+    val metadataFileId = "61ac0166-ccdf-48c4-800f-29e5fba2efda"
+
+    val expectedAssetMetadata = s"identifier,parentPath,title\n$assetId,$folderId,Test"
+    val expectedBagitTxt = "BagIt-Version: 1.0\nTag-File-Character-Encoding: UTF-8"
+    val expectedBagInfo = "Department: TEST\nSeries: TEST SERIES"
+    val expectedFileMetadata =
+      s"""identifier,parentPath,name,fileSize,title
+         |$fileId,$folderId/$assetId,Test.docx,15684,Test
+         |$metadataFileId,$folderId/$assetId,TRE-TEST-REFERENCE-metadata.json,215,""".stripMargin
+    val expectedFolderMetadata = s"identifier,parentPath,name,title\n$folderId,,cite,Test"
+    val expectedManifest = s"abcde data/$fileId\n81 data/$metadataFileId"
+    val expectedTagManifest =
+      "01 asset-metadata.csv\n21 bag-info.txt\n11 bagit.txt\n31 file-metadata.csv\n41 folder-metadata.csv\n51 manifest-sha256.txt"
+
+    filterEvents("asset-metadata.csv") should equal(expectedAssetMetadata)
+    filterEvents("bagit.txt") should equal(expectedBagitTxt)
+    filterEvents("bag-info.txt") should equal(expectedBagInfo)
+    filterEvents("file-metadata.csv") should equal(expectedFileMetadata)
+    filterEvents("folder-metadata.csv") should equal(expectedFolderMetadata)
+    filterEvents("manifest-sha256.txt") should equal(expectedManifest)
+    filterEvents("tagmanifest-sha256.txt") should equal(expectedTagManifest)
+
   }
 
   "the lambda" should "start the state machine execution with the correct parameters" in {
-    stubAWSRequests(inputBucket)
-    IngestParserTest().handleRequest(event, null)
-
-    val sfnEvent = sfnServer.getAllServeEvents.asScala.head
-    val sfnRequest = read[SFNRequest](sfnEvent.getRequest.getBodyAsString)
+    val sfnRequest = runLambdaAndReturnStepFunctionRequest()
     val input = read[Output](sfnRequest.input)
 
     sfnRequest.stateMachineArn should equal("arn:aws:states:eu-west-2:123456789:stateMachine:StateMachineName")
-    sfnRequest.name should equal(s"TEST-REFERENCE-${uuids(4)}")
+    sfnRequest.name should equal(s"TEST-REFERENCE-${uuids(4)._1}")
 
     input.series.get should equal("TEST SERIES")
     input.department.get should equal("TEST")
@@ -194,15 +245,12 @@ class LambdaTest extends AnyFlatSpec with BeforeAndAfterEach {
   "the lambda" should "start the state machine execution with a null department and series if the cite is missing" in {
     val inputJson =
       s"""{"parameters":{"TRE":{"reference":"$reference","payload":{"filename":"Test.docx","sha256":"abcde"}},"PARSER":{"uri":"https://example.com","court":"test","date":"2023-07-26","name":"test"}}}"""
-    stubAWSRequests(inputBucket, metadataJsonOpt = Option(inputJson))
-    IngestParserTest().handleRequest(event, null)
 
-    val sfnEvent = sfnServer.getAllServeEvents.asScala.head
-    val sfnRequest = read[SFNRequest](sfnEvent.getRequest.getBodyAsString)
+    val sfnRequest = runLambdaAndReturnStepFunctionRequest(Option(inputJson))
     val input = read[Output](sfnRequest.input)
 
     sfnRequest.stateMachineArn should equal("arn:aws:states:eu-west-2:123456789:stateMachine:StateMachineName")
-    sfnRequest.name should equal(s"TEST-REFERENCE-${uuids(4)}")
+    sfnRequest.name should equal(s"TEST-REFERENCE-${uuids(4)._1}")
 
     input.series should equal(None)
     input.department should equal(None)
@@ -214,15 +262,12 @@ class LambdaTest extends AnyFlatSpec with BeforeAndAfterEach {
   "the lambda" should "start the state machine execution with a null department and series if the cite is null" in {
     val inputJson =
       s"""{"parameters":{"TRE":{"reference":"$reference","payload":{"filename":"Test.docx","sha256":"abcde"}},"PARSER":{"cite": null, "uri":"https://example.com","court":"test","date":"2023-07-26","name":"test"}}}"""
-    stubAWSRequests(inputBucket, metadataJsonOpt = Option(inputJson))
-    IngestParserTest().handleRequest(event, null)
 
-    val sfnEvent = sfnServer.getAllServeEvents.asScala.head
-    val sfnRequest = read[SFNRequest](sfnEvent.getRequest.getBodyAsString)
+    val sfnRequest = runLambdaAndReturnStepFunctionRequest(Option(inputJson))
     val input = read[Output](sfnRequest.input)
 
     sfnRequest.stateMachineArn should equal("arn:aws:states:eu-west-2:123456789:stateMachine:StateMachineName")
-    sfnRequest.name should equal(s"TEST-REFERENCE-${uuids(4)}")
+    sfnRequest.name should equal(s"TEST-REFERENCE-${uuids(4)._1}")
 
     input.series should equal(None)
     input.department should equal(None)

--- a/src/test/scala/uk/gov/nationalarchives/SeriesMapperTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/SeriesMapperTest.scala
@@ -30,16 +30,16 @@ class SeriesMapperTest extends AnyFlatSpec with MockitoSugar with TableDrivenPro
   forAll(courtToSeries) { (court, series) =>
     "createOutput" should s"return $series for court $court" in {
       val seriesMapper = SeriesMapper()
-      val output = seriesMapper.createOutput("upload", "batch", s"2023 $court SUFFIX").unsafeRunSync()
-      output.department should equal(series.split(" ").head)
-      output.series should equal(series)
+      val output = seriesMapper.createOutput("upload", "batch", Option(s"2023 $court SUFFIX")).unsafeRunSync()
+      output.department.get should equal(series.split(" ").head)
+      output.series.get should equal(series)
     }
   }
 
   "createOutput" should "return the correct output if one series is found" in {
     val seriesMapper = SeriesMapper()
     val ex = intercept[RuntimeException] {
-      seriesMapper.createOutput("upload", "batch", s"2023 EWFC UKEAT").unsafeRunSync()
+      seriesMapper.createOutput("upload", "batch", Option(s"2023 EWFC UKEAT")).unsafeRunSync()
     }
     val expectedMessage = s"2 entries found when looking up series for cite 2023 EWFC UKEAT and batchId batch"
     ex.getMessage should equal(expectedMessage)
@@ -48,7 +48,7 @@ class SeriesMapperTest extends AnyFlatSpec with MockitoSugar with TableDrivenPro
   "createOutput" should "return an error if more than one series is found" in {
     val seriesMapper = SeriesMapper()
     val ex = intercept[RuntimeException] {
-      seriesMapper.createOutput("upload", "batch", s"2023 EWFC UKEAT").unsafeRunSync()
+      seriesMapper.createOutput("upload", "batch", Option(s"2023 EWFC UKEAT")).unsafeRunSync()
     }
     val expectedMessage = s"2 entries found when looking up series for cite 2023 EWFC UKEAT and batchId batch"
     ex.getMessage should equal(expectedMessage)
@@ -57,7 +57,7 @@ class SeriesMapperTest extends AnyFlatSpec with MockitoSugar with TableDrivenPro
   "createOutput" should "return an error if no series are found" in {
     val seriesMapper = SeriesMapper()
     val ex = intercept[RuntimeException] {
-      seriesMapper.createOutput("upload", "batch", s"2023 PREFIX SUFFIX").unsafeRunSync()
+      seriesMapper.createOutput("upload", "batch", Option(s"2023 PREFIX SUFFIX")).unsafeRunSync()
     }
     val expectedMessage = s"0 entries found when looking up series for cite 2023 PREFIX SUFFIX and batchId batch"
     ex.getMessage should equal(expectedMessage)

--- a/src/test/scala/uk/gov/nationalarchives/SeriesMapperTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/SeriesMapperTest.scala
@@ -36,15 +36,6 @@ class SeriesMapperTest extends AnyFlatSpec with MockitoSugar with TableDrivenPro
     }
   }
 
-  "createOutput" should "return the correct output if one series is found" in {
-    val seriesMapper = SeriesMapper()
-    val ex = intercept[RuntimeException] {
-      seriesMapper.createOutput("upload", "batch", Option(s"2023 EWFC UKEAT")).unsafeRunSync()
-    }
-    val expectedMessage = s"2 entries found when looking up series for cite 2023 EWFC UKEAT and batchId batch"
-    ex.getMessage should equal(expectedMessage)
-  }
-
   "createOutput" should "return an error if more than one series is found" in {
     val seriesMapper = SeriesMapper()
     val ex = intercept[RuntimeException] {
@@ -61,5 +52,13 @@ class SeriesMapperTest extends AnyFlatSpec with MockitoSugar with TableDrivenPro
     }
     val expectedMessage = s"0 entries found when looking up series for cite 2023 PREFIX SUFFIX and batchId batch"
     ex.getMessage should equal(expectedMessage)
+  }
+
+  "createOutput" should "return an empty department and series if the cite is missing" in {
+    val seriesMapper = SeriesMapper()
+    val output = seriesMapper.createOutput("upload", "batch", None).unsafeRunSync()
+
+    output.series should equal(None)
+    output.department should equal(None)
   }
 }


### PR DESCRIPTION
There are two scenarios.
1. The cite is not in the Map in the code. This should error and the
   lambda will exit. This already happens.
2. The cite is missing or empty in the TRE json file. In this case, we
   should pass a null series and department to the step function. This
   wasn't happening, there was no option to have a missing cite. I've
   changed it so this will work now.
