### PR TITLE
Rename identifier.

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/FileProcessor.scala
+++ b/src/main/scala/uk/gov/nationalarchives/FileProcessor.scala
@@ -225,7 +225,7 @@ object FileProcessor {
   case class AdditionalMetadata(key: String, value: String)
 
   case class BagitMetadataObject(
-      identifier: UUID,
+      id: UUID,
       parentId: Option[UUID],
       title: String,
       `type`: Type,


### PR DESCRIPTION
It's called id everywhere else including in Dynamo so it makes sense to
change it here.
