### PR TITLE
DR2-1197 Remove Press Summary of from the title.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,43 @@ The lambda does the following.
 
 The department and series lookup is very judgment-specific but this can be changed if we start taking in other transfers.
 
+## Metadata Mapping
+This table shows how we map the metadata from TRE to our bagit json.  
+Each field in a row is tried, if it's not null, it's used, otherwise the next field is tried.
+
+Given the following input json from TRE:
+```json
+{
+  "TRE": {
+    "payload": {
+      "filename": "Re RB (capacity).docx"
+    }
+  },
+  "PARSER": {
+    "cite": "[2023] EWFC 9",
+    "name": "Wiltshire County Council v RB"
+  }
+}
+```
+
+### Asset
+| Bagit metadata field |      |                              |
+|----------------------|------|------------------------------|
+| title                | name | filename (without extension) |
+| name                 | null |                              |
+
+### ArchiveFolder
+| Bagit metadata field |                                  |      |
+|----------------------|----------------------------------|------|
+| title                | name (without Press Summary of ) | ""   |
+| name                 | cite                             | null |
+
+### File
+| Bagit metadata field |                               |
+|----------------------|-------------------------------|
+| title                | filename (without extension ) |
+| name                 | filename                      |
+
 
 [Link to the infrastructure code](https://github.com/nationalarchives/dp-terraform-environments/blob/main/ingest_parsed_court_document_event_handler.tf)
 

--- a/src/main/scala/uk/gov/nationalarchives/FileProcessor.scala
+++ b/src/main/scala/uk/gov/nationalarchives/FileProcessor.scala
@@ -61,16 +61,26 @@ class FileProcessor(
       fileInfo: FileInfo,
       metadataFileInfo: FileInfo,
       cite: String,
+      name: Option[String],
       department: Option[String],
       series: Option[String]
   ): IO[String] = {
-    val title = fileInfo.fileName.split("\\.").dropRight(1).mkString(".")
+    val fileTitle = fileInfo.fileName.split("\\.").dropRight(1).mkString(".")
+    val folderTitle = name.map(_.stripPrefix("Press Summary of ")).getOrElse(fileTitle)
+    val assetTitle = name.getOrElse(fileTitle)
     val folderId = uuidGenerator()
     val assetId = uuidGenerator()
-    val folderMetadataObject = BagitMetadataObject(folderId, None, title, ArchiveFolder, Option(cite), None)
-    val assetMetadataObject = BagitMetadataObject(assetId, Option(folderId), title, Asset)
+    val folderMetadataObject = BagitMetadataObject(folderId, None, folderTitle, ArchiveFolder, Option(cite), None)
+    val assetMetadataObject = BagitMetadataObject(assetId, Option(folderId), assetTitle, Asset)
     val fileRowMetadataObject =
-      BagitMetadataObject(fileInfo.id, Option(assetId), title, File, Option(fileInfo.fileName), fileInfo.fileSize.some)
+      BagitMetadataObject(
+        fileInfo.id,
+        Option(assetId),
+        fileTitle,
+        File,
+        Option(fileInfo.fileName),
+        fileInfo.fileSize.some
+      )
     val fileMetadataObject = BagitMetadataObject(
       metadataFileInfo.id,
       Option(assetId),
@@ -246,7 +256,7 @@ object FileProcessor {
       court: String,
       cite: Option[String] = None,
       date: LocalDate,
-      name: String,
+      name: Option[String],
       attachments: List[String] = Nil,
       `error-messages`: List[String] = Nil
   )

--- a/src/main/scala/uk/gov/nationalarchives/FileProcessor.scala
+++ b/src/main/scala/uk/gov/nationalarchives/FileProcessor.scala
@@ -61,13 +61,13 @@ class FileProcessor(
       fileInfo: FileInfo,
       metadataFileInfo: FileInfo,
       cite: String,
-      name: Option[String],
+      judgmentName: Option[String],
       department: Option[String],
       series: Option[String]
   ): IO[String] = {
     val fileTitle = fileInfo.fileName.split("\\.").dropRight(1).mkString(".")
-    val folderTitle = name.map(_.stripPrefix("Press Summary of ")).getOrElse("")
-    val assetTitle = name.getOrElse(fileTitle)
+    val folderTitle = judgmentName.map(_.stripPrefix("Press Summary of ")).getOrElse("")
+    val assetTitle = judgmentName.getOrElse(fileTitle)
     val folderId = uuidGenerator()
     val assetId = uuidGenerator()
     val folderMetadataObject = BagitMetadataObject(folderId, None, folderTitle, ArchiveFolder, Option(cite), None)

--- a/src/main/scala/uk/gov/nationalarchives/FileProcessor.scala
+++ b/src/main/scala/uk/gov/nationalarchives/FileProcessor.scala
@@ -66,7 +66,7 @@ class FileProcessor(
       series: Option[String]
   ): IO[String] = {
     val fileTitle = fileInfo.fileName.split("\\.").dropRight(1).mkString(".")
-    val folderTitle = name.map(_.stripPrefix("Press Summary of ")).getOrElse(fileTitle)
+    val folderTitle = name.map(_.stripPrefix("Press Summary of ")).getOrElse("")
     val assetTitle = name.getOrElse(fileTitle)
     val folderId = uuidGenerator()
     val assetId = uuidGenerator()

--- a/src/main/scala/uk/gov/nationalarchives/Lambda.scala
+++ b/src/main/scala/uk/gov/nationalarchives/Lambda.scala
@@ -44,6 +44,7 @@ class Lambda extends RequestHandler[SQSEvent, Unit] {
           fileInfo.copy(checksum = payload.sha256),
           metadataFileInfo,
           cite.getOrElse("Court Documents"),
+          treMetadata.parameters.PARSER.name,
           output.department,
           output.series
         )

--- a/src/test/scala/uk/gov/nationalarchives/FileProcessorTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/FileProcessorTest.scala
@@ -211,7 +211,7 @@ class FileProcessorTest extends AnyFlatSpec with MockitoSugar with TableDrivenPr
   val treNameTable: TableFor3[Option[String], String, String] = Table(
     ("treName", "expectedFolderTitle", "expectedAssetTitle"),
     (Option("Test title"), "Test title", "Test title"),
-    (None, "fileName", "fileName"),
+    (None, "", "fileName"),
     (Option("Press Summary of test"), "test", "Press Summary of test")
   )
 

--- a/src/test/scala/uk/gov/nationalarchives/LambdaTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/LambdaTest.scala
@@ -196,7 +196,7 @@ class LambdaTest extends AnyFlatSpec with BeforeAndAfterEach {
     val assetId = UUID.fromString("c2e7866e-5e94-4b4e-a49f-043ad937c18a")
     val fileId = UUID.fromString("c7e6b27f-5778-4da8-9b83-1b64bbccbd03")
     val metadataFileId = UUID.fromString("61ac0166-ccdf-48c4-800f-29e5fba2efda")
-    val expectedAssetMetadata = BagitMetadataObject(assetId, Option(folderId), "Test", Asset)
+    val expectedAssetMetadata = BagitMetadataObject(assetId, Option(folderId), "test", Asset)
     val expectedBagitTxt = "BagIt-Version: 1.0\nTag-File-Character-Encoding: UTF-8"
     val expectedBagInfo = "Department: TEST\nSeries: TEST SERIES"
     val expectedFileMetadata = List(
@@ -210,7 +210,7 @@ class LambdaTest extends AnyFlatSpec with BeforeAndAfterEach {
         Option(215)
       )
     )
-    val expectedFolderMetadata = BagitMetadataObject(folderId, None, "Test", ArchiveFolder, Option("cite"), None)
+    val expectedFolderMetadata = BagitMetadataObject(folderId, None, "test", ArchiveFolder, Option("cite"), None)
     val expectedMetadata =
       (List(expectedFolderMetadata, expectedAssetMetadata) ++ expectedFileMetadata).asJson.printWith(Printer.noSpaces)
     val expectedManifest = s"abcde data/$fileId\n81 data/$metadataFileId"
@@ -223,7 +223,6 @@ class LambdaTest extends AnyFlatSpec with BeforeAndAfterEach {
     filterEvents("bag-info.txt") should equal(expectedBagInfo)
     filterEvents("manifest-sha256.txt") should equal(expectedManifest)
     filterEvents("tagmanifest-sha256.txt") should equal(expectedTagManifest)
-
   }
 
   "the lambda" should "start the state machine execution with the correct parameters" in {


### PR DESCRIPTION
There's a few corrections that needed to be made here.
The asset and folder title were taken from the docx filename without the
docx. This has been changed now to:
* For a folder use the name from the TRE json with "Press Summary of "
  removed. If this name is missing, use the docx filename.
* For an asset, do the same but don't strip out "Press summary of "

I've updated the tests to do a loop around the possible titles.

It looks like a lot of changes but it's mostly whitespace.
