### PR TITLE
DR2-1253 Add sortOrder to bagit json.

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/FileProcessor.scala
+++ b/src/main/scala/uk/gov/nationalarchives/FileProcessor.scala
@@ -7,6 +7,7 @@ import fs2.compression.Compression
 import fs2.interop.reactivestreams._
 import fs2.io._
 import fs2.{Chunk, Pipe, Stream, text}
+import io.circe.Json.Null
 import io.circe.generic.auto._
 import io.circe.generic.extras.Configuration
 import io.circe.generic.extras.semiauto.{deriveConfiguredDecoder, deriveConfiguredEncoder}
@@ -70,24 +71,26 @@ class FileProcessor(
     val assetTitle = judgmentName.getOrElse(fileTitle)
     val folderId = uuidGenerator()
     val assetId = uuidGenerator()
-    val folderMetadataObject = BagitMetadataObject(folderId, None, folderTitle, ArchiveFolder, Option(cite), None)
-    val assetMetadataObject = BagitMetadataObject(assetId, Option(folderId), assetTitle, Asset)
+    val folderMetadataObject = BagitFolderAssetMetadataObject(folderId, None, folderTitle, ArchiveFolder, Option(cite))
+    val assetMetadataObject = BagitFolderAssetMetadataObject(assetId, Option(folderId), assetTitle, Asset)
     val fileRowMetadataObject =
-      BagitMetadataObject(
+      BagitFileMetadataObject(
         fileInfo.id,
         Option(assetId),
         fileTitle,
         File,
+        1,
         Option(fileInfo.fileName),
-        fileInfo.fileSize.some
+        fileInfo.fileSize
       )
-    val fileMetadataObject = BagitMetadataObject(
+    val fileMetadataObject = BagitFileMetadataObject(
       metadataFileInfo.id,
       Option(assetId),
       "",
       File,
+      2,
       metadataFileInfo.fileName.some,
-      metadataFileInfo.fileSize.some
+      metadataFileInfo.fileSize
     )
     val metadata = List(folderMetadataObject, assetMetadataObject, fileRowMetadataObject, fileMetadataObject)
     val bagitString = "BagIt-Version: 1.0\nTag-File-Character-Encoding: UTF-8"
@@ -215,7 +218,34 @@ object FileProcessor {
   private val chunkSize: Int = 1024 * 64
   implicit val customConfig: Configuration = Configuration.default.withDefaults
   implicit val parserDecoder: Decoder[Parser] = deriveConfiguredDecoder
-  implicit val bagitMetadataEncoder: Encoder[BagitMetadataObject] = deriveConfiguredEncoder
+  implicit val bagitMetadataEncoder: Encoder[BagitMetadataObject] = {
+    case BagitFolderAssetMetadataObject(id, parentId, title, objectType, name) =>
+      jsonFromMetadataObject(id, parentId, title, objectType, name)
+    case BagitFileMetadataObject(id, parentId, title, objectType, sortOrder, name, fileSize) =>
+      Json
+        .obj(
+          ("sortOrder", Json.fromInt(sortOrder)),
+          ("fileSize", Json.fromLong(fileSize))
+        )
+        .deepMerge(jsonFromMetadataObject(id, parentId, title, objectType, name))
+  }
+
+  private def jsonFromMetadataObject(
+      id: UUID,
+      parentId: Option[UUID],
+      title: String,
+      objectType: Type,
+      name: Option[String]
+  ) = {
+    Json.obj(
+      ("id", Json.fromString(id.toString)),
+      ("parentId", parentId.map(_.toString).map(Json.fromString).getOrElse(Null)),
+      ("title", Json.fromString(title)),
+      ("type", objectType.asJson),
+      ("name", name.map(Json.fromString).getOrElse(Null))
+    )
+  }
+
   implicit val additionalMetadataEncoder: Encoder[AdditionalMetadata] = deriveConfiguredEncoder
 
   implicit val typeEncoder: Encoder[Type] = {
@@ -233,15 +263,31 @@ object FileProcessor {
   case object File extends Type
 
   case class AdditionalMetadata(key: String, value: String)
+  sealed trait BagitMetadataObject {
+    def id: UUID
+    def parentId: Option[UUID]
+    def title: String
+    def `type`: Type
+    def name: Option[String]
+  }
 
-  case class BagitMetadataObject(
+  case class BagitFolderAssetMetadataObject(
       id: UUID,
       parentId: Option[UUID],
       title: String,
       `type`: Type,
+      name: Option[String] = None
+  ) extends BagitMetadataObject
+
+  case class BagitFileMetadataObject(
+      id: UUID,
+      parentId: Option[UUID],
+      title: String,
+      `type`: Type,
+      sortOrder: Int,
       name: Option[String] = None,
-      fileSize: Option[Long] = None
-  )
+      fileSize: Long
+  ) extends BagitMetadataObject
 
   case class FileInfo(id: UUID, fileSize: Long, fileName: String, checksum: String)
 

--- a/src/test/scala/uk/gov/nationalarchives/FileProcessorTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/FileProcessorTest.scala
@@ -225,22 +225,15 @@ class FileProcessorTest extends AnyFlatSpec with MockitoSugar with TableDrivenPr
         val assetId = uuids.last
         val fileName = "fileName"
 
-        def bagitMetadataObject(
-            id: UUID,
-            `type`: Type,
-            name: Option[String] = None,
-            title: String,
-            parentId: Option[UUID] = None,
-            fileSize: Option[Long] = None
-        ) =
-          BagitMetadataObject(id, parentId, title, `type`, name, fileSize)
-        val folder = bagitMetadataObject(folderId, ArchiveFolder, Option("TEST-CITE"), expectedFolderTitle)
-        val asset = bagitMetadataObject(assetId, Asset, title = expectedAssetTitle, parentId = Option(folderId))
+        val folder =
+          BagitFolderAssetMetadataObject(folderId, None, expectedFolderTitle, ArchiveFolder, Option("TEST-CITE"))
+        val asset = BagitFolderAssetMetadataObject(assetId, Option(folderId), expectedAssetTitle, Asset)
         val files = List(
-          bagitMetadataObject(fileId, File, Option("fileName.txt"), fileName, Option(assetId), Option(1)),
-          bagitMetadataObject(metadataId, File, Option("metadataFileName.txt"), "", Option(assetId), Option(2))
+          BagitFileMetadataObject(fileId, Option(assetId), fileName, File, 1, Option("fileName.txt"), 1),
+          BagitFileMetadataObject(metadataId, Option(assetId), "", File, 2, Option("metadataFileName.txt"), 2)
         )
-        val metadataJsonString = (List(folder, asset) ++ files).asJson.printWith(Printer.noSpaces)
+        val metadataJsonList: List[BagitMetadataObject] = List(folder, asset) ++ files
+        val metadataJsonString = metadataJsonList.asJson.printWith(Printer.noSpaces)
 
         val bagitTxtContent =
           """BagIt-Version: 1.0

--- a/src/test/scala/uk/gov/nationalarchives/FileProcessorTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/FileProcessorTest.scala
@@ -226,11 +226,11 @@ class FileProcessorTest extends AnyFlatSpec with MockitoSugar with TableDrivenPr
         val fileName = "fileName"
 
         val folder =
-          BagitFolderAssetMetadataObject(folderId, None, expectedFolderTitle, ArchiveFolder, Option("TEST-CITE"))
-        val asset = BagitFolderAssetMetadataObject(assetId, Option(folderId), expectedAssetTitle, Asset)
+          BagitFolderMetadataObject(folderId, None, expectedFolderTitle, Option("TEST-CITE"))
+        val asset = BagitAssetMetadataObject(assetId, Option(folderId), expectedAssetTitle)
         val files = List(
-          BagitFileMetadataObject(fileId, Option(assetId), fileName, File, 1, Option("fileName.txt"), 1),
-          BagitFileMetadataObject(metadataId, Option(assetId), "", File, 2, Option("metadataFileName.txt"), 2)
+          BagitFileMetadataObject(fileId, Option(assetId), fileName, 1, "fileName.txt", 1),
+          BagitFileMetadataObject(metadataId, Option(assetId), "", 2, "metadataFileName.txt", 2)
         )
         val metadataJsonList: List[BagitMetadataObject] = List(folder, asset) ++ files
         val metadataJsonString = metadataJsonList.asJson.printWith(Printer.noSpaces)

--- a/src/test/scala/uk/gov/nationalarchives/LambdaTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/LambdaTest.scala
@@ -196,23 +196,25 @@ class LambdaTest extends AnyFlatSpec with BeforeAndAfterEach {
     val assetId = UUID.fromString("c2e7866e-5e94-4b4e-a49f-043ad937c18a")
     val fileId = UUID.fromString("c7e6b27f-5778-4da8-9b83-1b64bbccbd03")
     val metadataFileId = UUID.fromString("61ac0166-ccdf-48c4-800f-29e5fba2efda")
-    val expectedAssetMetadata = BagitMetadataObject(assetId, Option(folderId), "test", Asset)
+    val expectedAssetMetadata = BagitFolderAssetMetadataObject(assetId, Option(folderId), "test", Asset)
     val expectedBagitTxt = "BagIt-Version: 1.0\nTag-File-Character-Encoding: UTF-8"
     val expectedBagInfo = "Department: TEST\nSeries: TEST SERIES"
     val expectedFileMetadata = List(
-      BagitMetadataObject(fileId, Option(assetId), "Test", File, Option("Test.docx"), Option(15684)),
-      BagitMetadataObject(
+      BagitFileMetadataObject(fileId, Option(assetId), "Test", File, 1, Option("Test.docx"), 15684),
+      BagitFileMetadataObject(
         metadataFileId,
         Option(assetId),
         "",
         File,
+        2,
         Option("TRE-TEST-REFERENCE-metadata.json"),
-        Option(215)
+        215
       )
     )
-    val expectedFolderMetadata = BagitMetadataObject(folderId, None, "test", ArchiveFolder, Option("cite"), None)
-    val expectedMetadata =
-      (List(expectedFolderMetadata, expectedAssetMetadata) ++ expectedFileMetadata).asJson.printWith(Printer.noSpaces)
+    val expectedFolderMetadata = BagitFolderAssetMetadataObject(folderId, None, "test", ArchiveFolder, Option("cite"))
+    val metadataList: List[BagitMetadataObject] =
+      List(expectedFolderMetadata, expectedAssetMetadata) ++ expectedFileMetadata
+    val expectedMetadata = metadataList.asJson.printWith(Printer.noSpaces)
     val expectedManifest = s"abcde data/$fileId\n81 data/$metadataFileId"
     val expectedTagManifest =
       "21 bag-info.txt\n11 bagit.txt\n51 manifest-sha256.txt\n01 metadata.json"

--- a/src/test/scala/uk/gov/nationalarchives/LambdaTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/LambdaTest.scala
@@ -196,22 +196,21 @@ class LambdaTest extends AnyFlatSpec with BeforeAndAfterEach {
     val assetId = UUID.fromString("c2e7866e-5e94-4b4e-a49f-043ad937c18a")
     val fileId = UUID.fromString("c7e6b27f-5778-4da8-9b83-1b64bbccbd03")
     val metadataFileId = UUID.fromString("61ac0166-ccdf-48c4-800f-29e5fba2efda")
-    val expectedAssetMetadata = BagitFolderAssetMetadataObject(assetId, Option(folderId), "test", Asset)
+    val expectedAssetMetadata = BagitAssetMetadataObject(assetId, Option(folderId), "test")
     val expectedBagitTxt = "BagIt-Version: 1.0\nTag-File-Character-Encoding: UTF-8"
     val expectedBagInfo = "Department: TEST\nSeries: TEST SERIES"
     val expectedFileMetadata = List(
-      BagitFileMetadataObject(fileId, Option(assetId), "Test", File, 1, Option("Test.docx"), 15684),
+      BagitFileMetadataObject(fileId, Option(assetId), "Test", 1, "Test.docx", 15684),
       BagitFileMetadataObject(
         metadataFileId,
         Option(assetId),
         "",
-        File,
         2,
-        Option("TRE-TEST-REFERENCE-metadata.json"),
+        "TRE-TEST-REFERENCE-metadata.json",
         215
       )
     )
-    val expectedFolderMetadata = BagitFolderAssetMetadataObject(folderId, None, "test", ArchiveFolder, Option("cite"))
+    val expectedFolderMetadata = BagitFolderMetadataObject(folderId, None, "test", Option("cite"))
     val metadataList: List[BagitMetadataObject] =
       List(expectedFolderMetadata, expectedAssetMetadata) ++ expectedFileMetadata
     val expectedMetadata = metadataList.asJson.printWith(Printer.noSpaces)


### PR DESCRIPTION
This is then passed to the ingest mapper which puts it in Dynamo and
this is used to order the files in the xip.

I've done a bit of refactoring with the case classes as the asset/folder
and file entries have quite a few differences.
