### PR TITLE
DR2-1276 Delete procesed files from bucket root.

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 object Dependencies {
   lazy val logbackVersion = "2.20.0"
   lazy val pureConfigVersion = "0.17.4"
-  lazy val daAwsClientsVersion = "0.1.22"
+  lazy val daAwsClientsVersion = "0.1.26"
   private val circeVersion = "0.14.5"
   lazy val circeCore = "io.circe" %% "circe-core" % circeVersion
   lazy val circeGeneric = "io.circe" %% "circe-generic" % circeVersion

--- a/src/main/scala/uk/gov/nationalarchives/Lambda.scala
+++ b/src/main/scala/uk/gov/nationalarchives/Lambda.scala
@@ -51,7 +51,7 @@ class Lambda extends RequestHandler[SQSEvent, Unit] {
         _ <- s3.copy(outputBucket, fileInfo.id.toString, outputBucket, s"$batchRef/data/${fileInfo.id}")
         _ <- s3
           .copy(outputBucket, metadataFileInfo.id.toString, outputBucket, s"$batchRef/data/${metadataFileInfo.id}")
-
+        _ <- s3.deleteObjects(outputBucket, fileNameToFileInfo.values.map(_.id.toString).toList)
         _ <- sfn.startExecution(config.sfnArn, output, Option(s"$batchRef-${randomUuidGenerator()}"))
       } yield ()
     }.sequence


### PR DESCRIPTION
The lambda untars the files directly into the root of the bucket and
then moves them into the bagit structure.
This will delete the temporary files from the root which keeps the
bucket clean.

~~This depends on https://github.com/nationalarchives/da-aws-clients/pull/64 so the tests won't pass until that's merged but it's ready for review.~~

That's merged now and the tests are passing.