### PR TITLE
DR2-1226 Distinguish between unknown folder names.

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,4 @@
 version = 3.7.14
 preset = default
 runner.dialect = scala213
-maxColumn = 120
+maxColumn = 130

--- a/src/main/scala/uk/gov/nationalarchives/Lambda.scala
+++ b/src/main/scala/uk/gov/nationalarchives/Lambda.scala
@@ -43,7 +43,7 @@ class Lambda extends RequestHandler[SQSEvent, Unit] {
         _ <- fileProcessor.createMetadataFiles(
           fileInfo.copy(checksum = treMetadata.parameters.TDR.`Document-Checksum-sha256`),
           metadataFileInfo,
-          cite.getOrElse("Court Documents"),
+          cite,
           treMetadata.parameters.PARSER.name,
           output.department,
           output.series

--- a/src/main/scala/uk/gov/nationalarchives/LambdaRunner.scala
+++ b/src/main/scala/uk/gov/nationalarchives/LambdaRunner.scala
@@ -11,7 +11,7 @@ object LambdaRunner extends App {
   val json =
     """{"parameters": {"status": "OK", "reference": "TDR-2023-RMX", "s3Bucket": "dp-sam-test-bucket", "s3Key": "TRE-TDR-2023-RMW.tar.gz"}}"""
   val body =
-    "{\"parameters\": {\"status\": \"OK\", \"reference\": \"TDR-2023-RMW\", \"s3Bucket\": \"intg-ingest-parsed-court-document-event-handler-test-input\", \"s3Key\": \"TRE-TDR-2023-RMW.tar.gz\"}}"
+    "{\"parameters\": {\"status\": \"OK\", \"reference\": \"TST-2023-RMW\", \"s3Bucket\": \"intg-ingest-parsed-court-document-test-input\", \"s3Key\": \"TST-2023-RMW.tar.gz\"}}"
   val event = new SQSEvent()
   val record = new SQSMessage()
   record.setBody(body)

--- a/src/main/scala/uk/gov/nationalarchives/SeriesMapper.scala
+++ b/src/main/scala/uk/gov/nationalarchives/SeriesMapper.scala
@@ -9,15 +9,15 @@ class SeriesMapper(courts: Set[Court]) {
       .map { cite =>
         val filteredSeries = courts.filter(court => cite.contains(court.code))
         filteredSeries.size match {
-          case 1 =>
-            IO {
-              val court = filteredSeries.head
-              Output(batchId, uploadBucket, s"$batchId/", Option(court.dept), Option(court.series))
-            }
-          case size: Int =>
+          case size if size > 1 =>
             IO.raiseError(
               new RuntimeException(s"$size entries found when looking up series for cite $cite and batchId $batchId")
             )
+          case _ =>
+            IO {
+              val court = filteredSeries.headOption
+              Output(batchId, uploadBucket, s"$batchId/", court.map(_.dept), court.map(_.series))
+            }
         }
       }
       .getOrElse(IO(Output(batchId, uploadBucket, s"$batchId/", None, None)))

--- a/src/test/scala/uk/gov/nationalarchives/LambdaTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/LambdaTest.scala
@@ -222,7 +222,7 @@ class LambdaTest extends AnyFlatSpec with BeforeAndAfterEach {
         215
       )
     )
-    val expectedFolderMetadata = BagitFolderMetadataObject(folderId, None, "test", Option("cite"))
+    val expectedFolderMetadata = BagitFolderMetadataObject(folderId, None, Option("test"), "cite")
     val metadataList: List[BagitMetadataObject] =
       List(expectedFolderMetadata, expectedAssetMetadata) ++ expectedFileMetadata
     val expectedMetadata = metadataList.asJson.printWith(Printer.noSpaces)
@@ -335,9 +335,8 @@ class LambdaTest extends AnyFlatSpec with BeforeAndAfterEach {
     stubAWSRequests(inputBucket)
     IngestParserTest().handleRequest(event, null)
     val serveEvents = s3Server.getAllServeEvents.asScala
-    val deleteObjectsEvents = serveEvents.filter(e =>
-      e.getRequest.getUrl == s"/$testOutputBucket?delete" && e.getRequest.getMethod == RequestMethod.POST
-    )
+    val deleteObjectsEvents =
+      serveEvents.filter(e => e.getRequest.getUrl == s"/$testOutputBucket?delete" && e.getRequest.getMethod == RequestMethod.POST)
     deleteObjectsEvents.size should equal(1)
     deleteObjectsEvents.head.getRequest.getBodyAsString should equal(deleteRequestXml)
   }

--- a/src/test/scala/uk/gov/nationalarchives/SeriesMapperTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/SeriesMapperTest.scala
@@ -45,13 +45,12 @@ class SeriesMapperTest extends AnyFlatSpec with MockitoSugar with TableDrivenPro
     ex.getMessage should equal(expectedMessage)
   }
 
-  "createOutput" should "return an error if no series are found" in {
+  "createOutput" should "return an empty series if no series are found" in {
     val seriesMapper = SeriesMapper()
-    val ex = intercept[RuntimeException] {
-      seriesMapper.createOutput("upload", "batch", Option(s"2023 PREFIX SUFFIX")).unsafeRunSync()
-    }
-    val expectedMessage = s"0 entries found when looking up series for cite 2023 PREFIX SUFFIX and batchId batch"
-    ex.getMessage should equal(expectedMessage)
+    val output = seriesMapper.createOutput("upload", "batch", Option(s"2023 PREFIX SUFFIX")).unsafeRunSync()
+
+    output.series.isEmpty should equal(true)
+    output.department.isEmpty should equal(true)
   }
 
   "createOutput" should "return an empty department and series if the cite is missing" in {


### PR DESCRIPTION
The logic should be:

**Missing cite**
 ```json
{
  "id": "b38cbd84-e669-41f7-a95d-556fb86d30a8",
  "parentId": null,
  "title": null,
  "type": "ArchiveFolder",
  "name": "Court Documents (court unknown)"
}
```
**Cite present but lookup fails**
```json
{
  "id": "cd35e77d-f5d1-47e2-bef1-ca7d1490a740",
  "parentId": null,
  "title": null,
  "type": "ArchiveFolder",
  "name": "Court Documents (court not matched)"
}

```
**Cite present and lookup succeeds**
```json
{
  "id": "d81c6b6e-3dad-42d5-8bd5-fc8d68f4d0b8",
  "parentId": null,
  "title": "Judgment title",
  "type": "ArchiveFolder",
  "name": "CiteReference"
}

```

I've updated the tests to check for this.
