### PR TITLE
Add name to asset metadata.

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/Lambda.scala
+++ b/src/main/scala/uk/gov/nationalarchives/Lambda.scala
@@ -41,7 +41,7 @@ class Lambda extends RequestHandler[SQSEvent, Unit] {
         fileInfo <- IO.fromOption(fileNameToFileInfo.get(s"$batchRef/${payload.filename}"))(
           new RuntimeException(s"Document not found for file belonging to $batchRef")
         )
-        output <- seriesMapper.createOutput(config.outputBucket, batchRef, parsedUri.flatMap(_.cite))
+        output <- seriesMapper.createOutput(config.outputBucket, batchRef, parsedUri.flatMap(_.potentialCite))
         _ <- fileProcessor.createMetadataFiles(
           fileInfo.copy(checksum = treMetadata.parameters.TDR.`Document-Checksum-sha256`),
           metadataFileInfo,

--- a/src/test/scala/uk/gov/nationalarchives/LambdaTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/LambdaTest.scala
@@ -220,7 +220,7 @@ class LambdaTest extends AnyFlatSpec with BeforeAndAfterEach with TableDrivenPro
       val assetId = UUID.fromString("c2e7866e-5e94-4b4e-a49f-043ad937c18a")
       val fileId = UUID.fromString("c7e6b27f-5778-4da8-9b83-1b64bbccbd03")
       val metadataFileId = UUID.fromString("61ac0166-ccdf-48c4-800f-29e5fba2efda")
-      val expectedAssetMetadata = BagitAssetMetadataObject(assetId, Option(folderId), "test")
+      val expectedAssetMetadata = BagitAssetMetadataObject(assetId, Option(folderId), "Test.docx", "Test.docx")
       val expectedBagitTxt = "BagIt-Version: 1.0\nTag-File-Character-Encoding: UTF-8"
       val expectedBagInfo = "Department: TEST\nSeries: TEST SERIES"
       val expectedFileMetadata = List(


### PR DESCRIPTION
The name is mandatory but we're not setting it in here. I'm setting the
name and title to the filename. This is temporary, we'll update it later
but this will get the workflow working for now.
