### PR TITLE
DR2-1406 Map fileReference to BornDigitalRef

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/FileProcessor.scala
+++ b/src/main/scala/uk/gov/nationalarchives/FileProcessor.scala
@@ -69,7 +69,7 @@ class FileProcessor(
       potentialCite: Option[String],
       potentialJudgmentName: Option[String],
       potentialUri: Option[String],
-      reference: String,
+      potentialFileReference: String,
       fileReference: Option[String],
       department: Option[String],
       series: Option[String]
@@ -90,7 +90,7 @@ class FileProcessor(
       .map(cite => List(IdField("Code", cite), IdField("Cite", cite)) ++ uriIdField)
       .getOrElse(Nil)
     val assetMetadataIdFields = List(
-      Option(IdField("UpstreamSystemReference", reference)),
+      Option(IdField("UpstreamSystemReference", potentialFileReference)),
       potentialUri.map(uri => IdField("URI", uri)),
       potentialCite.map(cite => IdField("NeutralCitation", cite)),
       fileReference.map(ref => IdField("BornDigitalRef", ref))

--- a/src/main/scala/uk/gov/nationalarchives/FileProcessor.scala
+++ b/src/main/scala/uk/gov/nationalarchives/FileProcessor.scala
@@ -70,6 +70,7 @@ class FileProcessor(
       potentialJudgmentName: Option[String],
       potentialUri: Option[String],
       reference: String,
+      fileReference: Option[String],
       department: Option[String],
       series: Option[String]
   ): List[BagitMetadataObject] = {
@@ -91,7 +92,8 @@ class FileProcessor(
     val assetMetadataIdFields = List(
       Option(IdField("UpstreamSystemReference", reference)),
       potentialUri.map(uri => IdField("URI", uri)),
-      potentialCite.map(cite => IdField("NeutralCitation", cite))
+      potentialCite.map(cite => IdField("NeutralCitation", cite)),
+      fileReference.map(ref => IdField("BornDigitalRef", ref))
     ).flatten
     val fileTitle = fileInfo.fileName.split("\\.").dropRight(1).mkString(".")
     val folderId = uuidGenerator()
@@ -439,7 +441,8 @@ object FileProcessor {
       `Document-Checksum-sha256`: String,
       `Source-Organization`: String,
       `Internal-Sender-Identifier`: String,
-      `Consignment-Export-Datetime`: OffsetDateTime
+      `Consignment-Export-Datetime`: OffsetDateTime,
+      `File-Reference`: Option[String]
   )
 
   case class TREMetadataParameters(PARSER: Parser, TRE: TREParams, TDR: TDRParams)

--- a/src/main/scala/uk/gov/nationalarchives/Lambda.scala
+++ b/src/main/scala/uk/gov/nationalarchives/Lambda.scala
@@ -63,6 +63,7 @@ class Lambda extends RequestHandler[SQSEvent, Unit] {
           potentialJudgmentName,
           potentialUri,
           treMetadata.parameters.TRE.reference,
+          treMetadata.parameters.TDR.`File-Reference`,
           output.department,
           output.series
         )

--- a/src/test/scala/uk/gov/nationalarchives/FileProcessorTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/FileProcessorTest.scala
@@ -12,7 +12,7 @@ import org.mockito.{ArgumentMatcher, ArgumentMatchers, MockitoSugar}
 import org.reactivestreams.Publisher
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers._
-import org.scalatest.prop.{TableDrivenPropertyChecks, TableFor2, TableFor4, TableFor6}
+import org.scalatest.prop.{TableDrivenPropertyChecks, TableFor1, TableFor2, TableFor4, TableFor6}
 import reactor.core.publisher.Flux
 import software.amazon.awssdk.services.s3.model.PutObjectResponse
 import software.amazon.awssdk.transfer.s3.model.CompletedUpload
@@ -298,10 +298,10 @@ class FileProcessorTest extends AnyFlatSpec with MockitoSugar with TableDrivenPr
     (Option("cite"), List(IdField("Code", "cite"), IdField("Cite", "cite")))
   )
 
-  val fileReferenceTable: TableFor2[Option[String], List[IdField]] = Table(
-    ("potentialFileReference", "idFields"),
-    (None, Nil),
-    (Option("fileReference"), List(IdField("BornDigitalRef", "fileReference")))
+  val fileReferenceTable: TableFor1[Option[String]] = Table(
+    "potentialFileReference",
+    None,
+    Option("fileReference")
   )
 
   val urlDepartmentAndSeriesTable: TableFor6[Option[String], Option[String], Boolean, Option[ParsedUri], String, Boolean] = Table(
@@ -326,7 +326,7 @@ class FileProcessorTest extends AnyFlatSpec with MockitoSugar with TableDrivenPr
     (None, "fileName.txt", null, "fileName.txt"),
     (Option("Press Summary of test"), "Press Summary of test.txt", "test", "Press Summary of test.txt")
   )
-  forAll(fileReferenceTable) { (potentialFileReference, bornDigitalRefIdFields) =>
+  forAll(fileReferenceTable) { potentialFileReference =>
     forAll(citeTable) { (potentialCite, idFields) =>
       forAll(treNameTable) { (treName, treFileName, expectedFolderTitle, expectedAssetTitle) =>
         forAll(urlDepartmentAndSeriesTable) { (department, series, _, parsedUri, expectedFolderName, titleExpected) =>
@@ -355,8 +355,9 @@ class FileProcessorTest extends AnyFlatSpec with MockitoSugar with TableDrivenPr
                   List(
                     Option(IdField("UpstreamSystemReference", reference)),
                     potentialUri.map(uri => IdField("URI", uri)),
-                    potentialCite.map(cite => IdField("NeutralCitation", cite))
-                  ).flatten ++ bornDigitalRefIdFields
+                    potentialCite.map(cite => IdField("NeutralCitation", cite)),
+                    potentialFileReference.map(fileReference => IdField("BornDigitalRef", fileReference))
+                  ).flatten
                 )
               val files = List(
                 BagitFileMetadataObject(fileId, Option(assetId), fileName, 1, treFileName, 1),


### PR DESCRIPTION
File reference is optional for now as it's not been added yet. We should
make this mandatory at some point.

I've tested this with a package with the File-Reference attribute and
one without and it's working for both.
