### PR TITLE
DR2-1416 Improved logging.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,6 +17,8 @@ lazy val root = (project in file(".")).settings(
     log4jSlf4j,
     log4jCore,
     log4jTemplateJson,
+    log4CatsCore,
+    log4CatsSlf4j,
     lambdaCore,
     lambdaJavaEvents,
     pureConfig,
@@ -31,7 +33,7 @@ lazy val root = (project in file(".")).settings(
 )
 (assembly / assemblyJarName) := "dr2-ingest-parsed-court-document-event-handler.jar"
 
-scalacOptions ++= Seq("-Wunused:imports", "-Werror")
+scalacOptions ++= Seq("-Wunused:imports", "-Werror", "-deprecation")
 
 (Test / fork) := true
 (Test / envVars) := Map("AWS_ACCESS_KEY_ID" -> "accesskey", "AWS_SECRET_ACCESS_KEY" -> "secret")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,6 +5,7 @@ object Dependencies {
   lazy val daAwsClientsVersion = "0.1.35"
   private val fs2Version = "3.9.4"
   private val circeVersion = "0.14.6"
+  private val log4CatsVersion = "2.6.0"
 
   lazy val circeCore = "io.circe" %% "circe-core" % circeVersion
   lazy val circeGeneric = "io.circe" %% "circe-generic" % circeVersion
@@ -15,6 +16,8 @@ object Dependencies {
   lazy val log4jSlf4j = "org.apache.logging.log4j" % "log4j-slf4j-impl" % logbackVersion
   lazy val log4jCore = "org.apache.logging.log4j" % "log4j-core" % logbackVersion
   lazy val log4jTemplateJson = "org.apache.logging.log4j" % "log4j-layout-template-json" % logbackVersion
+  lazy val log4CatsCore= "org.typelevel" %% "log4cats-core" % log4CatsVersion;
+  lazy val log4CatsSlf4j = "org.typelevel" %% "log4cats-slf4j" % log4CatsVersion
   lazy val lambdaCore = "com.amazonaws" % "aws-lambda-java-core" % "1.2.3"
   lazy val lambdaJavaEvents = "com.amazonaws" % "aws-lambda-java-events" % "3.11.4"
   lazy val s3Client = "uk.gov.nationalarchives" %% "da-s3-client" % daAwsClientsVersion


### PR DESCRIPTION
This adds some extra logging to the lambda to make it easier to see what
is being processed.

The map that is passed as the first argument to logger.info is sent to
Cloudwatch as a json object that can be parsed in queries.
The first two log lines have only the batch ID as we don't yet have the
citeable reference from TRE.

The remainder of the log lines contain the batch ID and the citeable
reference. I've called it fileReference here as that's what TRE have
called it so it keeps it all consistent.

This logging is *not* meant to contain a comprehensive account of all
IDs that are passing through the system, for example, it says "Copied
bagit files to $outputBucket" The information as to exactly what they
are is in S3 and doesn't belong here. The focus is on making the logs
short and readable as guide to where a particular ingest is at the time.
