### PR TITLE
DR2-1352 Use batch id for execution name.

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/Lambda.scala
+++ b/src/main/scala/uk/gov/nationalarchives/Lambda.scala
@@ -80,7 +80,7 @@ class Lambda extends RequestHandler[SQSEvent, Unit] {
         _ <- s3
           .copy(outputBucket, metadataFileInfo.id.toString, outputBucket, s"$batchRef/data/${metadataFileInfo.id}")
         _ <- s3.deleteObjects(outputBucket, fileNameToFileInfo.values.map(_.id.toString).toList)
-        _ <- sfn.startExecution(config.sfnArn, output, Option(s"$batchRef-${randomUuidGenerator()}"))
+        _ <- sfn.startExecution(config.sfnArn, output, Option(s"$batchRef"))
       } yield ()
     }.sequence
   }.unsafeRunSync()

--- a/src/main/scala/uk/gov/nationalarchives/Lambda.scala
+++ b/src/main/scala/uk/gov/nationalarchives/Lambda.scala
@@ -80,7 +80,7 @@ class Lambda extends RequestHandler[SQSEvent, Unit] {
         _ <- s3
           .copy(outputBucket, metadataFileInfo.id.toString, outputBucket, s"$batchRef/data/${metadataFileInfo.id}")
         _ <- s3.deleteObjects(outputBucket, fileNameToFileInfo.values.map(_.id.toString).toList)
-        _ <- sfn.startExecution(config.sfnArn, output, Option(s"$batchRef"))
+        _ <- sfn.startExecution(config.sfnArn, output, Option(batchRef))
       } yield ()
     }.sequence
   }.unsafeRunSync()

--- a/src/test/scala/uk/gov/nationalarchives/LambdaTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/LambdaTest.scala
@@ -302,7 +302,7 @@ class LambdaTest extends AnyFlatSpec with BeforeAndAfterEach with TableDrivenPro
     val input = read[Output](sfnRequest.input)
 
     sfnRequest.stateMachineArn should equal("arn:aws:states:eu-west-2:123456789:stateMachine:StateMachineName")
-    sfnRequest.name should equal(s"TEST-REFERENCE-${uuidsAndChecksum(4)._1}")
+    sfnRequest.name should equal("TEST-REFERENCE")
 
     input.series.get should equal("TEST SERIES")
     input.department.get should equal("TEST")
@@ -332,7 +332,7 @@ class LambdaTest extends AnyFlatSpec with BeforeAndAfterEach with TableDrivenPro
       val input = read[Output](sfnRequest.input)
 
       sfnRequest.stateMachineArn should equal("arn:aws:states:eu-west-2:123456789:stateMachine:StateMachineName")
-      sfnRequest.name should equal(s"TEST-REFERENCE-${uuidsAndChecksum(4)._1}")
+      sfnRequest.name should equal("TEST-REFERENCE")
 
       input.series should equal(expectedSeries)
       input.department should equal(expectedDepartment)


### PR DESCRIPTION
We were originally going to let Preservica handle duplicate assets but
it looks like this doesn't work.

As a temporary solution, I've changed the step function execution name
to be just the batch id. This means that if a duplicate batch id comes
in, it will fail because the name already exists.
