### PR TITLE
Add the court to the error message

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/SeriesMapper.scala
+++ b/src/main/scala/uk/gov/nationalarchives/SeriesMapper.scala
@@ -15,7 +15,7 @@ class SeriesMapper(validCourts: Set[Court]) {
         val potentiallyFoundCourt: Option[Court] = validCourts.find(_.code == court.toUpperCase)
         potentiallyFoundCourt match {
           case None if skipSeriesLookup => IO(Output(batchId, uploadBucket, s"$batchId/", None, None))
-          case None                     => IO.raiseError(new Exception(s"Cannot find series and department for court $court"))
+          case None => IO.raiseError(new Exception(s"Cannot find series and department for court $court for batchId $batchId"))
           case _ =>
             IO(
               Output(batchId, uploadBucket, s"$batchId/", potentiallyFoundCourt.map(_.dept), potentiallyFoundCourt.map(_.series))

--- a/src/main/scala/uk/gov/nationalarchives/SeriesMapper.scala
+++ b/src/main/scala/uk/gov/nationalarchives/SeriesMapper.scala
@@ -15,7 +15,7 @@ class SeriesMapper(validCourts: Set[Court]) {
         val potentiallyFoundCourt: Option[Court] = validCourts.find(_.code == court.toUpperCase)
         potentiallyFoundCourt match {
           case None if skipSeriesLookup => IO(Output(batchId, uploadBucket, s"$batchId/", None, None))
-          case None                     => IO.raiseError(new Exception("Cannot find series and department for court"))
+          case None                     => IO.raiseError(new Exception(s"Cannot find series and department for court $court"))
           case _ =>
             IO(
               Output(batchId, uploadBucket, s"$batchId/", potentiallyFoundCourt.map(_.dept), potentiallyFoundCourt.map(_.series))

--- a/src/test/scala/uk/gov/nationalarchives/SeriesMapperTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/SeriesMapperTest.scala
@@ -42,7 +42,7 @@ class SeriesMapperTest extends AnyFlatSpec with MockitoSugar with TableDrivenPro
     val ex = intercept[Exception] {
       seriesMapper.createOutput("upload", "batch", Option("invalidCourt"), skipSeriesLookup = false).unsafeRunSync()
     }
-    val expectedMessage = s"Cannot find series and department for court"
+    val expectedMessage = s"Cannot find series and department for court invalidCourt"
     ex.getMessage should equal(expectedMessage)
   }
 

--- a/src/test/scala/uk/gov/nationalarchives/SeriesMapperTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/SeriesMapperTest.scala
@@ -42,7 +42,7 @@ class SeriesMapperTest extends AnyFlatSpec with MockitoSugar with TableDrivenPro
     val ex = intercept[Exception] {
       seriesMapper.createOutput("upload", "batch", Option("invalidCourt"), skipSeriesLookup = false).unsafeRunSync()
     }
-    val expectedMessage = s"Cannot find series and department for court invalidCourt"
+    val expectedMessage = s"Cannot find series and department for court invalidCourt for batchId batch"
     ex.getMessage should equal(expectedMessage)
   }
 


### PR DESCRIPTION
If we find a court that doesn't have a corresponding series or
department, it throws an error. This adds the court to the error so we
can do something about it.
